### PR TITLE
Allow setting labels per pod and deployment

### DIFF
--- a/misarch-catalog.tf
+++ b/misarch-catalog.tf
@@ -2,10 +2,8 @@ resource "kubernetes_deployment" "misarch_catalog" {
   depends_on = [helm_release.misarch_catalog_db, helm_release.dapr]
   metadata {
 
-    name = "misarch-catalog"
-    labels = {
-      app = "misarch-catalog"
-    }
+    name      = local.misarch_catalog_service_name
+    labels    = merge(local.base_misarch_labels, local.misarch_catalog_specific_labels)
     namespace = local.namespace
   }
 
@@ -14,15 +12,13 @@ resource "kubernetes_deployment" "misarch_catalog" {
 
     selector {
       match_labels = {
-        app = "misarch-catalog"
+        app = local.misarch_catalog_service_name
       }
     }
 
     template {
       metadata {
-        labels = {
-          app = "misarch-catalog"
-        }
+        labels      = merge(local.base_misarch_labels, local.misarch_catalog_specific_labels)
         annotations = merge(local.base_misarch_annotations, local.misarch_catalog_specific_annotations)
       }
 
@@ -32,7 +28,7 @@ resource "kubernetes_deployment" "misarch_catalog" {
           image             = "ghcr.io/misarch/catalog:${var.MISARCH_CATALOG_VERSION}"
           image_pull_policy = "Always"
 
-          name = "misarch-catalog"
+          name = local.misarch_catalog_service_name
 
           resources {
             limits = {

--- a/variables-labels.tf
+++ b/variables-labels.tf
@@ -1,0 +1,9 @@
+locals {
+  base_misarch_labels = {}
+}
+
+locals {
+  misarch_catalog_specific_labels = {
+    app = local.misarch_catalog_service_name
+  }
+}

--- a/variables-urls.tf
+++ b/variables-urls.tf
@@ -3,6 +3,7 @@ variable "ROOT_DOMAIN" {
   description = "Full URL the instance will be published on. Should not have a trailing slash."
 }
 
+// DBs
 locals {
   address_db_service_name      = "address-db"
   catalog_db_service_name      = "catalog-db"
@@ -20,12 +21,37 @@ locals {
   tax_db_service_name          = "tax-db"
   user_db_service_name         = "user-db"
   wishlist_db_service_name     = "wishlist-db"
+}
+
+// Services
+locals {
+  misarch_address_service_name      = "misarch-address"
+  misarch_catalog_service_name      = "misarch-catalog"
+  misarch_discount_service_name     = "misarch-discount"
+  misarch_inventory_service_name    = "misarch-inventory"
+  misarch_invoice_service_name      = "misarch-invoice"
+  misarch_media_service_name        = "misarch-media"
+  misarch_notification_service_name = "misarch-notification"
+  misarch_order_service_name        = "misarch-order"
+  misarch_payment_service_name      = "misarch-payment"
+  misarch_review_service_name       = "misarch-review"
+  misarch_return_service_name       = "misarch-return"
+  misarch_shipment_service_name     = "misarch-shipment"
+  misarch_shoppingcart_service_name = "misarch-shoppingcart"
+  misarch_tax_service_name          = "misarch-tax"
+  misarch_user_service_name         = "misarch-user"
+  misarch_wishlist_service_name     = "misarch-wishlist"
 
   otel_collector_service_name = "otel-collector"
+}
 
+// Ports
+locals {
   db_port             = 5432
   otel_collector_port = 4317
 }
+
+// DB Addresses
 locals {
   // The Postgresql HA Helm chart always appends '-postgresql', so we would need to add it to the URL too, if we switched to it
   address_db_full_service_name      = local.address_db_service_name # "${local.address_db_service_name}-postgresql"
@@ -48,6 +74,7 @@ locals {
   otel_collector_full_service_name = "${local.otel_collector_service_name}-opentelemetry-collector"
 }
 
+// Full DB URLs
 locals {
   address_db_url      = "${local.address_db_full_service_name}.${var.KUBERNETES_NAMESPACE}.svc.cluster.local:${local.db_port}"
   catalog_db_url      = "${local.catalog_db_full_service_name}.${var.KUBERNETES_NAMESPACE}.svc.cluster.local:${local.db_port}"


### PR DESCRIPTION
After this, only one point remains until a lot of services can be migrated at the same time.
Fixes https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/1dd12c3d-30fc-4b30-83c3-e7831d6818b4

## DoD

- [x] Requirements of the issue are met
- [x] `terraform apply` works
- [x] `kubectl get --namespace misarch` afterwards shows all pods up and running
- [x] `kubectl describe pod --namespace misarch misarch-catalog-<RANDOM STRING>` shows the custom labels
- [x] All pods can be started without problems