### PR TITLE
Create all DB passwords and outputs for them

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Afterwards, you can set up the cluster using
 terraform apply
 ```
 
+## Accessing DB Passwords
+
+All generated DB passwords can be retrieved by calling
+```sh
+terraform output misarch_${service_name_lowercased}_db_password
+```
+so for example
+```sh
+terraform output misarch_catalog_db_password
+# Or
+terraform output misarch_shoppingcart_db_password
+```
+
 ## Deployment Approach
 
 ### Terraform and State Management

--- a/passwords.tf
+++ b/passwords.tf
@@ -1,3 +1,4 @@
+// Passwords
 resource "random_password" "redis" {
   length  = 32
   special = false
@@ -8,7 +9,171 @@ resource "random_password" "keycloak_db_password" {
   special = false
 }
 
+resource "random_password" "misarch_address_db_password" {
+  length  = 32
+  special = false
+}
+
 resource "random_password" "misarch_catalog_db_password" {
   length  = 32
   special = false
 }
+
+resource "random_password" "misarch_discount_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_inventory_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_invoice_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_media_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_notification_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_order_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_payment_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_review_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_return_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_shipment_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_shoppingcart_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_tax_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_user_db_password" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "misarch_wishlist_db_password" {
+  length  = 32
+  special = false
+}
+
+
+
+
+// Ouputs for these passwords
+
+
+
+
+output "misarch_address_db_password" {
+  value = random_password.misarch_address_db_password.result
+  sensitive = true
+}
+
+output "misarch_catalog_db_password" {
+  value = random_password.misarch_catalog_db_password.result
+  sensitive = true
+}
+
+output "misarch_discount_db_password" {
+  value = random_password.misarch_discount_db_password.result
+  sensitive = true
+}
+
+output "misarch_inventory_db_password" {
+  value = random_password.misarch_inventory_db_password.result
+  sensitive = true
+}
+
+output "misarch_invoice_db_password" {
+  value = random_password.misarch_invoice_db_password.result
+  sensitive = true
+}
+
+output "misarch_media_db_password" {
+  value = random_password.misarch_media_db_password.result
+  sensitive = true
+}
+
+output "misarch_notification_db_password" {
+  value = random_password.misarch_notification_db_password.result
+  sensitive = true
+}
+
+output "misarch_order_db_password" {
+  value = random_password.misarch_order_db_password.result
+  sensitive = true
+}
+
+output "misarch_payment_db_password" {
+  value = random_password.misarch_payment_db_password.result
+  sensitive = true
+}
+
+output "misarch_review_db_password" {
+  value = random_password.misarch_review_db_password.result
+  sensitive = true
+}
+
+output "misarch_return_db_password" {
+  value = random_password.misarch_return_db_password.result
+  sensitive = true
+}
+
+output "misarch_shipment_db_password" {
+  value = random_password.misarch_shipment_db_password.result
+  sensitive = true
+}
+
+output "misarch_shoppingcart_db_password" {
+  value = random_password.misarch_shoppingcart_db_password.result
+  sensitive = true
+}
+
+output "misarch_tax_db_password" {
+  value = random_password.misarch_tax_db_password.result
+  sensitive = true
+}
+
+output "misarch_user_db_password" {
+  value = random_password.misarch_user_db_password.result
+  sensitive = true
+}
+
+output "misarch_wishlist_db_password" {
+  value = random_password.misarch_wishlist_db_password.result
+  sensitive = true
+}
+


### PR DESCRIPTION
Afterwards, the great <kbd>Ctrl</kbd><kbd>C</kbd> + <kbd>Ctrl</kbd><kbd>V</kbd> battle can begin.

Fixes https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/77aba02f-05a3-4979-90d4-87ee92a4d007

## DoD

- [x] Requirements of the issue are met
- [x] `terraform apply` works
- [x] `kubectl get --namespace misarch` afterwards shows all pods up and running
- [x] `terraform output misarch_shoppingcart_db_password` prints the password of the ShoppingCart DB