### PR TITLE
Convert official Keycloak image to the Bitnami Keycloak image

### DIFF
--- a/configmaps.tf
+++ b/configmaps.tf
@@ -1,6 +1,7 @@
 locals {
   misarch_base_env_vars_configmap = "misarch-base-env-vars"
 
+  keycloak_env_vars_configmap             = "keycloak-custom-env-vars"
   misarch_address_env_vars_configmap      = "misarch-address-env-vars"
   misarch_catalog_env_vars_configmap      = "misarch-catalog-env-vars"
   misarch_discount_env_vars_configmap     = "misarch-discount-env-vars"
@@ -25,6 +26,18 @@ resource "kubernetes_config_map" "base_misarch_env_vars" {
   metadata {
     name      = local.misarch_base_env_vars_configmap
     namespace = local.namespace
+  }
+}
+
+resource "kubernetes_config_map" "keycloak_env_vars" {
+  metadata {
+    name      = local.keycloak_env_vars_configmap
+    namespace = local.namespace
+  }
+
+  data = {
+    "KC_HOSTNAME_STRICT"  = "false"
+    "KEYCLOAK_EXTRA_ARGS" = "--import-realm"
   }
 }
 

--- a/variables-annotations.tf
+++ b/variables-annotations.tf
@@ -1,12 +1,16 @@
 locals {
   base_misarch_annotations = {
-    "dapr.io/enabled"   = true
-    "dapr.io/http-port" = 3500
+    "dapr.io/enabled"   = "true"
+    "dapr.io/http-port" = "3500"
     "dapr.io/config"    = local.dapr_general_config_name
   }
 }
 
 locals {
+  keycloak_specific_annotations = {
+    "dapr.io/app-id"   = "keycloak"
+    "dapr.io/app-port" = "8080" # '""' needed because of Helm
+  }
   misarch_address_specific_annotations = {
     "dapr.io/app-id"   = "address"
     "dapr.io/app-port" = 8080

--- a/variables-versions.tf
+++ b/variables-versions.tf
@@ -5,7 +5,7 @@ variable "POSTGRES_VERSION" {
 
 variable "KEYCLOAK_VERSION" {
   type    = string
-  default = "23.0"
+  default = "23"
 }
 
 variable "KEYCLOAK_ADMIN_PASSWORD" {
@@ -16,7 +16,7 @@ variable "KEYCLOAK_ADMIN_PASSWORD" {
 
 variable "KEYCLOAK_USER_EVENTS_PLUGIN_VERSION" {
   type    = string
-  default = "v0.0.2"
+  default = "v0.0.4"
 }
 
 variable "MISARCH_ADDRESS_VERSION" {


### PR DESCRIPTION
Afterwards, K8s should start again and work more reliably than before…

At least I now know why the keycloak setup behaved so weirdly before (as in options seemed completely different than described in the docs)

Fixes https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/e6666d64-f044-4b88-906e-e998d7e3d223

## DoD

- [x] Keycloak works when setting up a fresh K8s cluster
- [x] Keycloak is connected to Dapr