### PR TITLE
Add shipment to the setup

### DIFF
--- a/configmaps.tf
+++ b/configmaps.tf
@@ -208,6 +208,7 @@ resource "kubernetes_config_map" "misarch_shipment_env_vars" {
     "SPRING_FLYWAY_URL"     = "jdbc:postgresql://${local.shipment_db_url}/${var.MISARCH_DB_DATABASE}"
     "SPRING_R2DBC_USERNAME" = var.MISARCH_DB_USER
     "SPRING_R2DBC_PASSWORD" = random_password.misarch_shipment_db_password.result
+    "MISARCH_SHIPMENT_PROVIDER_ENDPOINT" = "http://localhost/does-not-exist" # To who is responsible for creating the simulation service: We are waiting for the full service!
   }
 }
 

--- a/misarch-shipment.tf
+++ b/misarch-shipment.tf
@@ -1,0 +1,58 @@
+resource "kubernetes_deployment" "misarch_shipment" {
+  depends_on = [helm_release.misarch_shipment_db, helm_release.dapr]
+  metadata {
+
+    name      = local.misarch_shipment_service_name
+    labels    = merge(local.base_misarch_labels, local.misarch_shipment_specific_labels)
+    namespace = local.namespace
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = local.misarch_shipment_service_name
+      }
+    }
+
+    template {
+      metadata {
+        labels      = merge(local.base_misarch_labels, local.misarch_shipment_specific_labels)
+        annotations = merge(local.base_misarch_annotations, local.misarch_shipment_specific_annotations)
+      }
+
+      spec {
+
+        container {
+          image             = "ghcr.io/misarch/shipment:${var.MISARCH_SHIPMENT_VERSION}"
+          image_pull_policy = "Always"
+
+          name = local.misarch_shipment_service_name
+
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "1200Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "400Mi"
+            }
+          }
+
+          env_from {
+            config_map_ref {
+              name = local.misarch_base_env_vars_configmap
+            }
+          }
+          env_from {
+            config_map_ref {
+              name = local.misarch_shipment_env_vars_configmap
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/b3d09f51-4312-4ef0-9ef8-386f0749e816

## DoD

- [x] Requirements of the issue are met
- [x] `terraform apply` works
- [x] Waiting for a bit and then executing `kubectl get pod --namespace misarch` after running terraform apply shows all pods, especially the Shipment pod and its db, up and running