### PR TITLE
Make Keycloak requests successful

### DIFF
--- a/configmaps.tf
+++ b/configmaps.tf
@@ -36,8 +36,8 @@ resource "kubernetes_config_map" "keycloak_env_vars" {
   }
 
   data = {
-    "KC_HOSTNAME_STRICT"  = "false"
-    "KEYCLOAK_EXTRA_ARGS" = "--import-realm"
+    "KC_HOSTNAME_STRICT"              = "false"
+    "KEYCLOAK_EXTRA_ARGS"             = "--import-realm"
     "QUARKUS_HTTP_ACCESS_LOG_ENABLED" = "true" // for easier debugging, can just as well be deleted
   }
 }
@@ -91,7 +91,7 @@ resource "kubernetes_config_map" "misarch_frontend_env_vars" {
   }
 
   data = {
-    "GATEWAY_ENDPOINT" = local.dapr_misarch_gateway_url
+    "GATEWAY_ENDPOINT"  = local.dapr_misarch_gateway_url
     "KEYCLOAK_ENDPOINT" = "http://${local.keycloak_url}"
   }
 }
@@ -206,10 +206,10 @@ resource "kubernetes_config_map" "misarch_shipment_env_vars" {
   }
 
   data = {
-    "SPRING_R2DBC_URL"      = "r2dbc:postgresql://${local.shipment_db_url}/${var.MISARCH_DB_DATABASE}"
-    "SPRING_FLYWAY_URL"     = "jdbc:postgresql://${local.shipment_db_url}/${var.MISARCH_DB_DATABASE}"
-    "SPRING_R2DBC_USERNAME" = var.MISARCH_DB_USER
-    "SPRING_R2DBC_PASSWORD" = random_password.misarch_shipment_db_password.result
+    "SPRING_R2DBC_URL"                   = "r2dbc:postgresql://${local.shipment_db_url}/${var.MISARCH_DB_DATABASE}"
+    "SPRING_FLYWAY_URL"                  = "jdbc:postgresql://${local.shipment_db_url}/${var.MISARCH_DB_DATABASE}"
+    "SPRING_R2DBC_USERNAME"              = var.MISARCH_DB_USER
+    "SPRING_R2DBC_PASSWORD"              = random_password.misarch_shipment_db_password.result
     "MISARCH_SHIPMENT_PROVIDER_ENDPOINT" = "http://localhost/does-not-exist" # To who is responsible for creating the simulation service: We are waiting for the full service!
   }
 }

--- a/configmaps.tf
+++ b/configmaps.tf
@@ -38,6 +38,7 @@ resource "kubernetes_config_map" "keycloak_env_vars" {
   data = {
     "KC_HOSTNAME_STRICT"  = "false"
     "KEYCLOAK_EXTRA_ARGS" = "--import-realm"
+    "QUARKUS_HTTP_ACCESS_LOG_ENABLED" = "true" // for easier debugging, can just as well be deleted
   }
 }
 

--- a/keycloak.tf
+++ b/keycloak.tf
@@ -25,8 +25,7 @@ resource "helm_release" "keycloak" {
         username: "misarch"
         password: "${random_password.keycloak_db_password.result}"
         database: "misarch"
-    ingress:
-      hostname: "${var.ROOT_DOMAIN}"
+    httpRelativePath: "/keycloak/"
     metrics:
       enabled: true
     initContainers:

--- a/misarch-frontend.tf
+++ b/misarch-frontend.tf
@@ -1,5 +1,5 @@
 resource "kubernetes_deployment" "misarch_frontend" {
-  depends_on = [terraform_data.dapr]
+  depends_on = [terraform_data.dapr, helm_release.keycloak]
   metadata {
 
     name      = local.misarch_frontend_service_name

--- a/variables-annotations.tf
+++ b/variables-annotations.tf
@@ -1,8 +1,10 @@
 locals {
   base_misarch_annotations = {
-    "dapr.io/enabled"   = "true"
-    "dapr.io/http-port" = "3500"
-    "dapr.io/config"    = local.dapr_general_config_name
+    "dapr.io/enabled"               = "true"
+    "dapr.io/http-port"             = "3500"
+    "dapr.io/config"                = local.dapr_general_config_name
+    "dapr.io/log-level"             = "debug"
+    "dapr.io/http-read-buffer-size" = "20" # KB, apparently the default of 4KB is too small in our usecase
 
     "dapr.io/sidecar-liveness-probe-threshold"      = "10"
     "dapr.io/sidecar-liveness-probe-delay-seconds"  = "10"

--- a/variables-urls.tf
+++ b/variables-urls.tf
@@ -103,7 +103,7 @@ locals {
 // Service URLs
 locals {
   dapr_url           = "http://localhost:${local.dapr_port}"
-  keycloak_url = "${local.keycloak_service_name}.${var.KUBERNETES_NAMESPACE}.svc.cluster.local:${local.keycloak_port}"
+  keycloak_url       = "${local.keycloak_service_name}.${var.KUBERNETES_NAMESPACE}.svc.cluster.local:${local.keycloak_port}"
   otel_collector_url = "${local.otel_collector_full_service_name}.${var.KUBERNETES_NAMESPACE}.svc.cluster.local:${local.otel_collector_port}"
 }
 

--- a/variables-urls.tf
+++ b/variables-urls.tf
@@ -53,7 +53,7 @@ locals {
 locals {
   dapr_port           = 3500
   db_port             = 5432
-  keycloak_port       = 8080
+  keycloak_port       = 80
   otel_collector_port = 4317
 }
 

--- a/variables-urls.tf
+++ b/variables-urls.tf
@@ -53,7 +53,7 @@ locals {
 locals {
   dapr_port           = 3500
   db_port             = 5432
-  keycloak_port       = 80
+  keycloak_port       = 80 # Okay, weird things are happening here: While keycloak runs under `8080`, the keycloak svc exposes port `80`. In other words, there is even an internal redirect happening here?
   otel_collector_port = 4317
 }
 


### PR DESCRIPTION
Afterwards, requests to Keycloak succeed.
There is one catch that we (@nk-coding and I) encountered with Dapr requests failing for an unknown reason on one specific cluster deterministically.
However, after a lengthy debugging session, we can conclude that it seems to be caused by the cluster itself rather than our changes.

Fixes https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/c6abc9bf-c422-4b73-ada6-a3dd743906d9

## DoD

- [x] Running `terraform apply` creates the cluster
- [x] When port-forwarding the frontend, the frontend loads
- [x] On the port-forwarded frontend, you can login and register on Keycloak
- [x] You can visit the Keycloak admin console from the port-forwarded frontend
- [x] The GraphQL queries succeed, so they don't complain about no authentication being present