### PR TITLE
Create ingress

### DIFF
--- a/ingress.tf
+++ b/ingress.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_ingress_v1" "misarch" {
   metadata {
-    name      = local.misarch_ingress_name
-    namespace = local.misarch_namespace
+    name      = local.ingress_name
+    namespace = local.namespace
     annotations = merge(local.base_misarch_annotations, local.misarch_ingress_annotations)
   }
 

--- a/ingress.tf
+++ b/ingress.tf
@@ -1,0 +1,34 @@
+resource "kubernetes_ingress_v1" "misarch" {
+  metadata {
+    name      = local.misarch_ingress_name
+    namespace = local.misarch_namespace
+    annotations = merge(local.base_misarch_annotations, local.misarch_ingress_annotations)
+  }
+
+  spec {
+    default_backend {
+      service {
+        name = local.misarch_frontend_service_name
+        port {
+          number = local.frontend_port
+        }
+      }
+    }
+
+    rule {
+      http {
+        path {
+          backend {
+            service {
+              name = local.misarch_frontend_service_name
+              port {
+                number = local.frontend_port
+              }
+            }
+          }
+          path = "/"
+        }
+      }
+    }
+  }
+}

--- a/ingress.tf
+++ b/ingress.tf
@@ -32,3 +32,26 @@ resource "kubernetes_ingress_v1" "misarch" {
     }
   }
 }
+
+resource "kubernetes_service" "misarch_frontend_service" {
+  metadata {
+    name      = local.misarch_frontend_service_name
+    namespace = local.namespace
+    labels    = merge(local.base_misarch_labels, local.misarch_frontend_specific_labels)
+  }
+
+  spec {
+    selector = {
+      app = local.misarch_frontend_service_name
+    }
+
+    port {
+      protocol    = "TCP"
+      port        = local.frontend_port
+      target_port = local.frontend_port
+    }
+
+    type = "ClusterIP"
+  }
+}
+

--- a/otel.tf
+++ b/otel.tf
@@ -7,6 +7,8 @@ resource "helm_release" "otel-collector" {
   values = [
     <<-EOF
     mode: "deployment"
+    image:
+      repository: "otel/opentelemetry-collector-k8s" # https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/UPGRADING.md#0880-to-0890
     EOF
   ]
 }

--- a/variables-annotations.tf
+++ b/variables-annotations.tf
@@ -14,6 +14,11 @@ locals {
 }
 
 locals {
+  misarch_ingress_annotations = {
+    "kubernetes.io/ingress.class"                   = "nginx"
+    "nginx.ingress.kubernetes.io/proxy-body-size"   = "10m"
+    "nginx.ingress.kubernetes.io/proxy-buffer-size" = "10m"
+  }
   keycloak_specific_annotations = {
     "dapr.io/app-id"   = "keycloak"
     "dapr.io/app-port" = "8080" # '""' needed because of Helm

--- a/variables-urls.tf
+++ b/variables-urls.tf
@@ -25,6 +25,7 @@ locals {
 
 // Services
 locals {
+  ingress_name          = "misarch-ingress"
   keycloak_service_name = "keycloak"
 
   misarch_address_service_name      = "misarch-address"
@@ -54,6 +55,7 @@ locals {
   dapr_port           = 3500
   db_port             = 5432
   keycloak_port       = 80 # Okay, weird things are happening here: While keycloak runs under `8080`, the keycloak svc exposes port `80`. In other words, there is even an internal redirect happening here?
+  frontend_port       = 80
   otel_collector_port = 4317
 }
 


### PR DESCRIPTION
Now, the `misarch` namespace should be automatically queriable once you configure a URL where the cluster is accessible.

I've tested it as far as possible (the frontend service works, and the ingress looks good to me as well, but I'm unable to test it).
Fixes https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/17f8db7d-ba65-4d20-be47-ea59209ececb

## DoD

- [x] Initializing the cluster and running `kubectl port-forward --namespace misarch services/misarch-frontend 4000:80` shows the frontend on port `4000`
- [x] Keycloak inside the frontend works