### PR TITLE
Setup remaining mongodb services

### DIFF
--- a/configmaps.tf
+++ b/configmaps.tf
@@ -125,10 +125,7 @@ resource "kubernetes_config_map" "misarch_invoice_env_vars" {
   }
 
   data = {
-    "SPRING_R2DBC_URL"      = "r2dbc:postgresql://${local.invoice_db_url}/${var.MISARCH_DB_DATABASE}"
-    "SPRING_FLYWAY_URL"     = "jdbc:postgresql://${local.invoice_db_url}/${var.MISARCH_DB_DATABASE}"
-    "SPRING_R2DBC_USERNAME" = var.MISARCH_DB_USER
-    "SPRING_R2DBC_PASSWORD" = random_password.misarch_invoice_db_password.result
+    "ME_CONFIG_MONGODB_URL" = "mongodb://${local.invoice_db_url}"
   }
 }
 
@@ -166,7 +163,9 @@ resource "kubernetes_config_map" "misarch_order_env_vars" {
     namespace = local.namespace
   }
 
-  data = {}
+  data = {
+    "ME_CONFIG_MONGODB_URL" = "mongodb://${local.order_db_url}"
+  }
 }
 
 resource "kubernetes_config_map" "misarch_payment_env_vars" {
@@ -175,7 +174,11 @@ resource "kubernetes_config_map" "misarch_payment_env_vars" {
     namespace = local.namespace
   }
 
-  data = {}
+  data = {
+    "DATABASE_URI" = "mongodb://${local.payment_db_url}"
+    "DATABASE_NAME" = var.MISARCH_DB_DATABASE
+    "SIMULATION_URL" = "http://${local.simulation_url}"
+  }
 }
 
 resource "kubernetes_config_map" "misarch_review_env_vars" {
@@ -184,7 +187,9 @@ resource "kubernetes_config_map" "misarch_review_env_vars" {
     namespace = local.namespace
   }
 
-  data = {}
+  data = {
+    "ME_CONFIG_MONGODB_URL" = "mongodb://${local.review_db_url}"
+  }
 }
 
 resource "kubernetes_config_map" "misarch_return_env_vars" {
@@ -222,7 +227,9 @@ resource "kubernetes_config_map" "misarch_shoppingcart_env_vars" {
     namespace = local.namespace
   }
 
-  data = {}
+  data = {
+    "ME_CONFIG_MONGODB_URL" = "mongodb://${local.shoppingcart_db_url}"
+  }
 }
 
 resource "kubernetes_config_map" "misarch_tax_env_vars" {
@@ -259,6 +266,8 @@ resource "kubernetes_config_map" "misarch_wishlist_env_vars" {
     namespace = local.namespace
   }
 
-  data = {}
+  data = {
+    "ME_CONFIG_MONGODB_URL" = "mongodb://${local.wishlist_db_url}"
+  }
 }
 

--- a/dbs-mongodb.tf
+++ b/dbs-mongodb.tf
@@ -45,8 +45,6 @@ resource "kubernetes_secret" "mongodb_credentials_inventory" {
   }
 }
 
-/* Uncomment once our cluster is powerful enough to handle the remaining DBs
-
 # Invoice
 resource "helm_release" "misarch_invoice_db" {
   depends_on = [kubernetes_secret.mongodb_credentials_invoice]
@@ -268,5 +266,3 @@ resource "kubernetes_secret" "mongodb_credentials_wishlist" {
     "mongodb-replica-set-key"   = random_password.mongodb_replica_set_key_wishlist.result
   }
 }
-
-*/

--- a/misarch-invoice.tf
+++ b/misarch-invoice.tf
@@ -1,0 +1,59 @@
+resource "kubernetes_deployment" "misarch_invoice" {
+  depends_on = [helm_release.misarch_invoice_db, terraform_data.dapr]
+  metadata {
+
+    name      = local.misarch_invoice_service_name
+    labels    = merge(local.base_misarch_labels, local.misarch_invoice_specific_labels)
+    namespace = local.namespace
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = local.misarch_invoice_service_name
+      }
+    }
+
+    template {
+      metadata {
+        labels      = merge(local.base_misarch_labels, local.misarch_invoice_specific_labels)
+        annotations = merge(local.base_misarch_annotations, local.misarch_invoice_specific_annotations)
+      }
+
+      spec {
+
+        container {
+          image             = "ghcr.io/misarch/invoice:${var.MISARCH_INVOICE_VERSION}"
+          image_pull_policy = "Always"
+
+          name = local.misarch_invoice_service_name
+
+
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "1200Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "400Mi"
+            }
+          }
+
+          env_from {
+            config_map_ref {
+              name = local.misarch_base_env_vars_configmap
+            }
+          }
+          env_from {
+            config_map_ref {
+              name = local.misarch_invoice_env_vars_configmap
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/misarch-order.tf
+++ b/misarch-order.tf
@@ -1,0 +1,59 @@
+resource "kubernetes_deployment" "misarch_order" {
+  depends_on = [helm_release.misarch_order_db, terraform_data.dapr]
+  metadata {
+
+    name      = local.misarch_order_service_name
+    labels    = merge(local.base_misarch_labels, local.misarch_order_specific_labels)
+    namespace = local.namespace
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = local.misarch_order_service_name
+      }
+    }
+
+    template {
+      metadata {
+        labels      = merge(local.base_misarch_labels, local.misarch_order_specific_labels)
+        annotations = merge(local.base_misarch_annotations, local.misarch_order_specific_annotations)
+      }
+
+      spec {
+
+        container {
+          image             = "ghcr.io/misarch/order:${var.MISARCH_ORDER_VERSION}"
+          image_pull_policy = "Always"
+
+          name = local.misarch_order_service_name
+
+
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "1200Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "400Mi"
+            }
+          }
+
+          env_from {
+            config_map_ref {
+              name = local.misarch_base_env_vars_configmap
+            }
+          }
+          env_from {
+            config_map_ref {
+              name = local.misarch_order_env_vars_configmap
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/misarch-payment.tf
+++ b/misarch-payment.tf
@@ -1,0 +1,59 @@
+resource "kubernetes_deployment" "misarch_payment" {
+  depends_on = [helm_release.misarch_payment_db, terraform_data.dapr]
+  metadata {
+
+    name      = local.misarch_payment_service_name
+    labels    = merge(local.base_misarch_labels, local.misarch_payment_specific_labels)
+    namespace = local.namespace
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = local.misarch_payment_service_name
+      }
+    }
+
+    template {
+      metadata {
+        labels      = merge(local.base_misarch_labels, local.misarch_payment_specific_labels)
+        annotations = merge(local.base_misarch_annotations, local.misarch_payment_specific_annotations)
+      }
+
+      spec {
+
+        container {
+          image             = "ghcr.io/misarch/payment:${var.MISARCH_PAYMENT_VERSION}"
+          image_pull_policy = "Always"
+
+          name = local.misarch_payment_service_name
+
+
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "1200Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "400Mi"
+            }
+          }
+
+          env_from {
+            config_map_ref {
+              name = local.misarch_base_env_vars_configmap
+            }
+          }
+          env_from {
+            config_map_ref {
+              name = local.misarch_payment_env_vars_configmap
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/misarch-review.tf
+++ b/misarch-review.tf
@@ -1,0 +1,59 @@
+resource "kubernetes_deployment" "misarch_review" {
+  depends_on = [helm_release.misarch_review_db, terraform_data.dapr]
+  metadata {
+
+    name      = local.misarch_review_service_name
+    labels    = merge(local.base_misarch_labels, local.misarch_review_specific_labels)
+    namespace = local.namespace
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = local.misarch_review_service_name
+      }
+    }
+
+    template {
+      metadata {
+        labels      = merge(local.base_misarch_labels, local.misarch_review_specific_labels)
+        annotations = merge(local.base_misarch_annotations, local.misarch_review_specific_annotations)
+      }
+
+      spec {
+
+        container {
+          image             = "ghcr.io/misarch/review:${var.MISARCH_REVIEW_VERSION}"
+          image_pull_policy = "Always"
+
+          name = local.misarch_review_service_name
+
+
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "1200Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "400Mi"
+            }
+          }
+
+          env_from {
+            config_map_ref {
+              name = local.misarch_base_env_vars_configmap
+            }
+          }
+          env_from {
+            config_map_ref {
+              name = local.misarch_review_env_vars_configmap
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/misarch-shoppingcart.tf
+++ b/misarch-shoppingcart.tf
@@ -1,0 +1,59 @@
+resource "kubernetes_deployment" "misarch_shoppingcart" {
+  depends_on = [helm_release.misarch_shoppingcart_db, terraform_data.dapr]
+  metadata {
+
+    name      = local.misarch_shoppingcart_service_name
+    labels    = merge(local.base_misarch_labels, local.misarch_shoppingcart_specific_labels)
+    namespace = local.namespace
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = local.misarch_shoppingcart_service_name
+      }
+    }
+
+    template {
+      metadata {
+        labels      = merge(local.base_misarch_labels, local.misarch_shoppingcart_specific_labels)
+        annotations = merge(local.base_misarch_annotations, local.misarch_shoppingcart_specific_annotations)
+      }
+
+      spec {
+
+        container {
+          image             = "ghcr.io/misarch/shoppingcart:${var.MISARCH_SHOPPINGCART_VERSION}"
+          image_pull_policy = "Always"
+
+          name = local.misarch_shoppingcart_service_name
+
+
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "1200Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "400Mi"
+            }
+          }
+
+          env_from {
+            config_map_ref {
+              name = local.misarch_base_env_vars_configmap
+            }
+          }
+          env_from {
+            config_map_ref {
+              name = local.misarch_shoppingcart_env_vars_configmap
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/misarch-wishlist.tf
+++ b/misarch-wishlist.tf
@@ -1,0 +1,59 @@
+resource "kubernetes_deployment" "misarch_wishlist" {
+  depends_on = [helm_release.misarch_wishlist_db, terraform_data.dapr]
+  metadata {
+
+    name      = local.misarch_wishlist_service_name
+    labels    = merge(local.base_misarch_labels, local.misarch_wishlist_specific_labels)
+    namespace = local.namespace
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = local.misarch_wishlist_service_name
+      }
+    }
+
+    template {
+      metadata {
+        labels      = merge(local.base_misarch_labels, local.misarch_wishlist_specific_labels)
+        annotations = merge(local.base_misarch_annotations, local.misarch_wishlist_specific_annotations)
+      }
+
+      spec {
+
+        container {
+          image             = "ghcr.io/misarch/wishlist:${var.MISARCH_WISHLIST_VERSION}"
+          image_pull_policy = "Always"
+
+          name = local.misarch_wishlist_service_name
+
+
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "1200Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "400Mi"
+            }
+          }
+
+          env_from {
+            config_map_ref {
+              name = local.misarch_base_env_vars_configmap
+            }
+          }
+          env_from {
+            config_map_ref {
+              name = local.misarch_wishlist_env_vars_configmap
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/variables-urls.tf
+++ b/variables-urls.tf
@@ -43,6 +43,7 @@ locals {
   misarch_return_service_name       = "misarch-return"
   misarch_shipment_service_name     = "misarch-shipment"
   misarch_shoppingcart_service_name = "misarch-shoppingcart"
+  misarch_simulation_service_name   = "misarch-simulation"
   misarch_tax_service_name          = "misarch-tax"
   misarch_user_service_name         = "misarch-user"
   misarch_wishlist_service_name     = "misarch-wishlist"
@@ -55,6 +56,7 @@ locals {
   dapr_port           = 3500
   keycloak_port       = 80 # Okay, weird things are happening here: While keycloak runs under `8080`, the keycloak svc exposes port `80`. In other words, there is even an internal redirect happening here?
   frontend_port       = 80
+  simulation_port     = 8080
   mongo_db_port       = 27017
   postgres_db_port    = 5432
   otel_collector_port = 4317
@@ -110,6 +112,7 @@ locals {
 locals {
   dapr_url           = "http://localhost:${local.dapr_port}"
   keycloak_url       = "${local.keycloak_service_name}.${var.KUBERNETES_NAMESPACE}.svc.cluster.local:${local.keycloak_port}"
+  simulation_url     = "${local.misarch_simulation_service_name}.${var.KUBERNETES_NAMESPACE}.svc.cluster.local:${local.simulation_port}"
   otel_collector_url = "${local.otel_collector_full_service_name}.${var.KUBERNETES_NAMESPACE}.svc.cluster.local:${local.otel_collector_port}"
 }
 


### PR DESCRIPTION
Now, `Invoice`, `Order`, `Payment`, `Review`, `Shoppingcart`, and `Wishlist` have been set up as well.

Unfortunately, there is not enough CPU to test the changes yet on the cluster, as such it is a "let's hope it works".

## Fixed issues
- [invoice](https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/a184d091-0b90-49b3-a290-61881d6fb4e6)
- [order](https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/c2c245f2-e903-42b9-a916-f6ba9c60d966)
- [payment](https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/3d384efb-b02d-4381-aef8-c67ddcf53dda)
- [review](https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/217400e6-0dab-44d8-a441-103e54ce7c75)
- [shoppingcart](https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/62aa0f45-da50-4393-9ddb-67ead54dbeea)
- [wishlist](https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/4657911d-b5b6-4fc9-bdfc-087ea029a745)

## DoD

- [x] These services have been added to the deployment
- [x] These services are connected to Dapr
- [x] `terraform apply` works
- [x] Waiting for a bit and then executing `kubectl get pod --namespace misarch` after running `terraform apply` shows all pods, especially these services and their DB, up and running
