### PR TITLE
Setup return

### DIFF
--- a/misarch-return.tf
+++ b/misarch-return.tf
@@ -1,0 +1,58 @@
+resource "kubernetes_deployment" "misarch_return" {
+  depends_on = [helm_release.misarch_return_db, terraform_data.dapr]
+  metadata {
+
+    name      = local.misarch_return_service_name
+    labels    = merge(local.base_misarch_labels, local.misarch_return_specific_labels)
+    namespace = local.namespace
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        app = local.misarch_return_service_name
+      }
+    }
+
+    template {
+      metadata {
+        labels      = merge(local.base_misarch_labels, local.misarch_return_specific_labels)
+        annotations = merge(local.base_misarch_annotations, local.misarch_return_specific_annotations)
+      }
+
+      spec {
+
+        container {
+          image             = "ghcr.io/misarch/return:${var.MISARCH_RETURN_VERSION}"
+          image_pull_policy = "Always"
+
+          name = local.misarch_return_service_name
+
+          resources {
+            limits = {
+              cpu    = "500m"
+              memory = "1200Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "400Mi"
+            }
+          }
+
+          env_from {
+            config_map_ref {
+              name = local.misarch_base_env_vars_configmap
+            }
+          }
+          env_from {
+            config_map_ref {
+              name = local.misarch_return_env_vars_configmap
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/variables-versions.tf
+++ b/variables-versions.tf
@@ -81,7 +81,7 @@ variable "MISARCH_PAYMENT_VERSION" {
 
 variable "MISARCH_RETURN_VERSION" {
   type    = string
-  default = "v0.0.1"
+  default = "v0.0.2"
 }
 
 variable "MISARCH_REVIEW_VERSION" {


### PR DESCRIPTION
Fixes https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/5109d439-1c41-4cbd-abb2-baf10dac2ac4

## DoD

- [x] The Return service is added to the deployment
- [x] The Return service is connected to Dapr
- [x] `terraform apply` works
- [x] Waiting for a bit and then executing `kubectl get pod --namespace misarch` after running `terraform apply` shows all pods, especially the Return pod and its DB, up and running